### PR TITLE
Add endpoint /cities-app/soap/ with SOAP input/output

### DIFF
--- a/apps/address_registry/tests/test_views.py
+++ b/apps/address_registry/tests/test_views.py
@@ -1,5 +1,6 @@
 import pytest
 from model_bakery.baker import make
+from spyne.client.django import DjangoTestClient
 
 from apps.address_registry.models import (
     Apskritis,
@@ -13,6 +14,7 @@ from apps.address_registry.models import (
     Savivaldybe,
     Seniunija,
 )
+from apps.address_registry.views import cities_application_soap
 from apps.utils.tests_query_counter import APIClientWithQueryCounter
 
 
@@ -402,6 +404,42 @@ def test_content_types(client: APIClientWithQueryCounter, endpoint: str, frmt: s
     response = client.get(f"/api/v1/demo/{frmt}/{endpoint}")
     assert response.status_code == 200
     assert response.headers["Content-Type"] == content_type
+
+
+class TestCitiesApplication:
+    @pytest.fixture
+    def client(self) -> DjangoTestClient:
+        return DjangoTestClient("/api/v1/cities-app/soap/", cities_application_soap.app)
+
+    def test_city_response(self, client: DjangoTestClient) -> None:
+        gyvenviete = make(Gyvenviete)
+        pavadinimas1 = make(Pavadinimas, linksnis="VARDININKAS", gyvenviete=gyvenviete)
+        pavadinimas2 = make(Pavadinimas, linksnis="KILMININKAS", gyvenviete=gyvenviete)
+
+        response = client.service.cities.get_django_response()
+        assert response.status_code == 200
+
+        response_data = list(client.service.cities())
+        assert len(response_data) == 1
+
+        data = response_data[0]
+        assert data.id == gyvenviete.id
+        assert len(data.pavadinimo_formos) == 2
+        assert {data.pavadinimo_formos[0].id, data.pavadinimo_formos[1].id} == {pavadinimas1.id, pavadinimas2.id}
+
+    def test_city_name_response(self, client: DjangoTestClient) -> None:
+        gyvenviete = make(Gyvenviete)
+        pavadinimas = make(Pavadinimas, gyvenviete=gyvenviete)
+
+        response = client.service.city_names.get_django_response()
+        assert response.status_code == 200
+
+        response_data = list(client.service.city_names())
+        assert len(response_data) == 1
+
+        data = response_data[0]
+        assert data.id == pavadinimas.id
+        assert data.gyvenviete.id == gyvenviete.id
 
 
 class TestGenerateTestData:

--- a/apps/address_registry/urls.py
+++ b/apps/address_registry/urls.py
@@ -2,6 +2,7 @@ from django.urls import include, path, re_path
 
 from apps.address_registry.views import (
     GenerateTestData,
+    cities_application_soap,
     demo_application_json,
     demo_application_soap,
     demo_application_xml,
@@ -15,6 +16,14 @@ urlpatterns = [
                 re_path(r"^json/", demo_application_json),
                 re_path(r"^soap/", demo_application_soap),
                 re_path(r"^xml/", demo_application_xml),
+            ]
+        ),
+    ),
+    path(
+        "cities-app/",
+        include(
+            [
+                re_path(r"^soap/", cities_application_soap),
             ]
         ),
     ),

--- a/apps/address_registry/urls.py
+++ b/apps/address_registry/urls.py
@@ -2,6 +2,7 @@ from django.urls import include, path, re_path
 
 from apps.address_registry.views import (
     GenerateTestData,
+    cities_application_json,
     cities_application_soap,
     demo_application_json,
     demo_application_soap,
@@ -24,6 +25,7 @@ urlpatterns = [
         include(
             [
                 re_path(r"^soap/", cities_application_soap),
+                re_path(r"^json/", cities_application_json),
             ]
         ),
     ),

--- a/apps/address_registry/views.py
+++ b/apps/address_registry/views.py
@@ -13,7 +13,7 @@ from spyne.protocol.soap import Soap11
 from spyne.protocol.xml import XmlDocument
 from spyne.server.django import DjangoApplication
 
-from apps.address_registry.services import DemoService
+from apps.address_registry.services import CityNameService, CityService, DemoService
 
 demo_application_json = csrf_exempt(
     DjangoApplication(
@@ -49,6 +49,19 @@ demo_application_xml = csrf_exempt(
             name="Demo XML Service",
             in_protocol=HttpRpc(validator="soft"),
             out_protocol=XmlDocument(validator="soft"),
+        )
+    )
+)
+
+
+cities_application_soap = csrf_exempt(
+    DjangoApplication(
+        Application(
+            [CityService, CityNameService],
+            tns="cities_application_tns",
+            name="CitiesApplication",
+            in_protocol=Soap11(validator="lxml"),
+            out_protocol=Soap11(validator="soft"),
         )
     )
 )

--- a/apps/address_registry/views.py
+++ b/apps/address_registry/views.py
@@ -67,6 +67,19 @@ cities_application_soap = csrf_exempt(
 )
 
 
+cities_application_json = csrf_exempt(
+    DjangoApplication(
+        Application(
+            [CityService, CityNameService],
+            tns="cities_application_tns",
+            name="CitiesApplication",
+            in_protocol=HttpRpc(validator="soft"),
+            out_protocol=JsonDocument(validator="soft"),
+        )
+    )
+)
+
+
 class GenerateTestDataSerializer(serializers.Serializer):
     quantity = serializers.IntegerField(min_value=1, max_value=1000, required=True)
 


### PR DESCRIPTION
**Summary:**

Adds SOAP endpoints:
* `/api/v1/cities-app/soap/city_names/`
* `/api/v1/cities-app/soap/cities/`

Both endpoints expects SOAP input and gives SOAP output. These are added as part of Spinta WSDL/SOAP implementation task and can be used for testing.

**Ticket:**
https://github.com/atviriduomenys/spinta/issues/1273