### PR TITLE
DSA pavyzdys perkeltas į manifests direktoriją

### DIFF
--- a/manifest/datasets/gov/vssa/example/sql/dsa_sql_nepilnas.csv
+++ b/manifest/datasets/gov/vssa/example/sql/dsa_sql_nepilnas.csv
@@ -1,5 +1,5 @@
 dataset,resource,base,model,property,type,ref,source,access,prepare,level,uri
-example,,,,,sql,,,,,,
+datasets/gov/vssa/example/sql,,,,,dataset,,,,,,
 ,api,,,,sql,,postgresql://django:django@localhost:9432/django,,,,
 ,,,,,,,,,,,
 ,,,Salis,,,id,address_registry_salis,open,,,


### PR DESCRIPTION
**Summary:**

Esamas DSA pavyzdys `dsa_examples/dsa_sql_nepilnas.csv` perkeltas į `manifests/` direktoriją, tam, kad būtų galima tęsti darbus su `demo-saltiniai` paleidimu, kol nėra užbaigtas https://github.com/atviriduomenys/demo-saltiniai/pull/12