### PR TITLE
add runner to drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -23,3 +23,5 @@ volumes:
 - name: docker_sock
   host:
     path: /var/run/docker.sock
+node:
+  label: runner


### PR DESCRIPTION
Added 
```
node:
  label: runner
```
  to `.drone.yml` to fix pending deployment (https://drone.data.gov.lt/atviriduomenys/demo-saltiniai/29), as suggested by Tautvydas.